### PR TITLE
Fix memory leak

### DIFF
--- a/Cbc/src/CbcModel.cpp
+++ b/Cbc/src/CbcModel.cpp
@@ -7522,7 +7522,7 @@ CbcModel::synchronizeHandlers(int /*makeDefault*/)
     bool defaultHandler = defaultHandler_;
     if (!defaultHandler_) {
         // Must have clone
-        handler_ = handler_->clone();
+        //handler_ = handler_->clone();
         defaultHandler_ = true;
     }
 #ifdef COIN_HAS_CLP


### PR DESCRIPTION
A memory leak is caused by the line:

handler_ = handler_->clone();

in CbcModel::synchronizeHandlers(int)
