### PR TITLE
fix Cbc_clone return value (return the new model, not the old one)

### DIFF
--- a/Cbc/src/Cbc_C_Interface.cpp
+++ b/Cbc/src/Cbc_C_Interface.cpp
@@ -756,7 +756,8 @@ Cbc_clone(Cbc_Model * model)
     result->cmdargs_   = model->cmdargs_;
 
     if (VERBOSE > 0) printf("%s return\n", prefix);
-    return model;
+    //return model;
+    return result;
 }
 /** Set this the variable to be continuous */
 COINLIBAPI void COINLINKAGE


### PR DESCRIPTION
does anyone use Cbc_clone ?

i think there is a mistake : it returns the wrong object

returning **result**  instead of **model** works fine for me
